### PR TITLE
Refs #23996 - Fix and extend tests for user update

### DIFF
--- a/lib/hammer_cli_foreman/testing/api_expectations.rb
+++ b/lib/hammer_cli_foreman/testing/api_expectations.rb
@@ -63,11 +63,18 @@ module HammerCLIForeman
           if @api_call_matcher && !@api_call_matcher.expected_params.empty?
             signature += "\n  expected params to include: " + params_signature(@api_call_matcher.expected_params)
           end
+          if @api_call_matcher && !@api_call_matcher.block.nil?
+            signature += "\n  expected params to match block at: " + block_signature(@api_call_matcher.block)
+          end
           signature
         end
 
         def params_signature(hash)
           JSON.pretty_generate(hash).split("\n").join("\n  ")
+        end
+
+        def block_signature(block)
+          block.source_location.join(':')
         end
 
         def set_note(note)
@@ -127,6 +134,10 @@ module HammerCLIForeman
       class TestAuthenticator < ApipieBindings::Authenticators::BasicAuth
         def user(ask=nil)
           @user
+        end
+
+        def password(ask=nil)
+          @password
         end
       end
 

--- a/test/functional/user_test.rb
+++ b/test/functional/user_test.rb
@@ -7,12 +7,12 @@ describe "user" do
 
   def expect_with_minimal_params(action, message, &block)
     api_expects(:users, action, message).with_params({
-      'user' => {'login' => 'jane', 'mail' => 'jane@test.org', 'password' => 'secret', 'auth_source_id' => 1}})
+      'user' => {'login' => 'jane', 'mail' => 'jane@test.org', 'password' => 'secret', 'auth_source_id' => 1}}, &block)
   end
 
   def expect_with_update_params(action, message, &block)
     api_expects(:users, action, message).with_params({
-      'user' => {'login' => 'jane'}})
+      'user' => {'login' => 'jane'}}, &block)
   end
 
   describe "create" do
@@ -80,6 +80,86 @@ describe "user" do
 
       result = run_cmd(cmd + update_params + params)
       assert_cmd(expected_result, result)
+    end
+
+    describe "update password" do
+      def replace_foreman_connection(connection)
+        HammerCLI.context[:api_connection].drop('foreman')
+        HammerCLI.context[:api_connection].create('foreman') { connection }
+      end
+
+      def connection(user, password)
+        authenticator = TestAuthenticator.new(user, password)
+        api_connection({:authenticator => authenticator}, FOREMAN_VERSION)
+      end
+
+      before do
+        @original_api_connection = HammerCLI.context[:api_connection].get('foreman')
+      end
+
+      after do
+        replace_foreman_connection(@original_api_connection)
+      end
+
+      it 'asks for missing current user password when updating own password' do
+        replace_foreman_connection(connection('jane', nil))
+
+        params = ['--password', 'changeme']
+
+        api_expects_search(:users, { :login => 'jane' }).returns(index_response([user]))
+        api_expects(:users, :show, { :id => 'jane' }).returns(user)
+        HammerCLIForeman::OptionSources::UserParams.any_instance
+          .expects(:ask_password).with(:current).returns('currentpwd')
+        expect_with_update_params(:update, 'Update user password') do |par|
+          par['id'] == '32' &&
+            par['user']['password'] == 'changeme' &&
+            par['user']['current_password'] == 'currentpwd'
+        end.returns(user)
+
+        expected_result = success_result("User [jane] updated.\n")
+        result = run_cmd(cmd + update_params + params)
+        assert_cmd(expected_result, result)
+      end
+
+      it 'does not ask for missing current password when updating own password and password was already given' do
+        replace_foreman_connection(connection('jane', 'currentpwd'))
+
+        params = ['--password', 'changeme']
+
+        api_expects_search(:users, { :login => 'jane' }).returns(index_response([user]))
+        api_expects(:users, :show, { :id => 'jane' }).returns(user)
+        HammerCLIForeman::OptionSources::UserParams.any_instance
+          .expects(:ask_password).with(:current).never
+        expect_with_update_params(:update, 'Update user password') do |par|
+          par['id'] == '32' &&
+            par['user']['password'] == 'changeme' &&
+            par['user']['current_password'] == 'currentpwd'
+        end.returns(user)
+
+        expected_result = success_result("User [jane] updated.\n")
+        result = run_cmd(cmd + update_params + params)
+        assert_cmd(expected_result, result)
+      end
+
+      it 'does not ask for current user password when updating password of another user' do
+        user_john = { 'id' => '1', 'login' => 'john' }
+        replace_foreman_connection(connection('john', nil))
+
+        params = ['--password', 'changeme']
+
+        api_expects_search(:users, { :login => 'jane' }).returns(index_response([user]))
+        api_expects(:users, :show, { :id => 'john' }).returns(user_john)
+        HammerCLIForeman::OptionSources::UserParams.any_instance
+          .expects(:ask_password).with(:current).never
+        expect_with_update_params(:update, 'Update user password') do |par|
+          par['id'] == '32' &&
+            par['user']['password'] == 'changeme'
+        end.returns(user)
+
+        expected_result = success_result("User [jane] updated.\n")
+        result = run_cmd(cmd + update_params + params)
+        assert_cmd(expected_result, result)
+      end
     end
   end
 end


### PR DESCRIPTION
Some of functional tests for user update were not working as expected and some were missing. This patch makes the expectation blocks actually being executed and adds tests for updates of the password. 